### PR TITLE
Add "fork me" banner, README, and warnings detail for distributions

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,3 @@
 This simple Dancer-based module powers http://smoke.perl6.org
+
+The script for generating the smoke results can be found at https://github.com/tadzik/emmentaler

--- a/lib/SmokeResults.pm
+++ b/lib/SmokeResults.pm
@@ -18,19 +18,21 @@ my $rect_size    = 15;
 my $path = $ENV{SMOKE_HISTORY_PATH} // "$ENV{HOME}/smoke-history";
 
 my %color = (
-    ok      => '<div class="smfok">✓</div>',
-    black   => '<div class="smfmissing">?</div>',
-    test    => '<div class="smftest">T</div>',
-    build   => '<div class="smfbuild">B</div>',
-    prereq  => '<div class="smfprereq">P</div>',
+    ok       => '<div class="smfok">✓</div>',
+    black    => '<div class="smfmissing">?</div>',
+    test     => '<div class="smftest">T</div>',
+    build    => '<div class="smfbuild">B</div>',
+    prereq   => '<div class="smfprereq">P</div>',
+    warnings => '<div class="smfwarn">W</div>',
 );
 
 my %explanation = (
-    ok      => 'Passes all tests',
-    black   => 'No info available',
-    test    => 'Tests fail',
-    build   => 'Build fails',
-    prereq  => 'Prerequisites failing',
+    ok       => 'Passes all tests',
+    black    => 'No info available',
+    test     => 'Tests fail',
+    build    => 'Build fails',
+    prereq   => 'Prerequisites failing',
+    warnings => 'Build/tests had warnings',
 );
 
 sub get_all_dates {

--- a/lib/SmokeResults.pm
+++ b/lib/SmokeResults.pm
@@ -149,13 +149,13 @@ sub get_projects_report {
                         last;
                     }
                 }
-                unless ($failed) {
-                    $color = $color{ok};
-                    $count{$date}{ok}++;
-                }
 
                 if ($res->{warnings}) {
                     $color = $color{warnings};
+                    $count{$date}{warnings}++;
+                } elsif (!$failed) {
+                    $color = $color{ok};
+                    $count{$date}{ok}++;
                 }
             }
             

--- a/lib/SmokeResults.pm
+++ b/lib/SmokeResults.pm
@@ -192,7 +192,7 @@ sub get_projects_report {
     }
     
     my $key = [];
-    foreach my $k ("ok", "test", "build", "prereq", "black") {
+    foreach my $k ("ok", "test", "build", "prereq", "warnings", "black") {
         push @$key, [ 
             $color{$k}, 
             $explanation{$k}, 

--- a/lib/SmokeResults.pm
+++ b/lib/SmokeResults.pm
@@ -153,6 +153,10 @@ sub get_projects_report {
                     $color = $color{ok};
                     $count{$date}{ok}++;
                 }
+
+                if ($res->{warnings}) {
+                    $color = $color{warnings};
+                }
             }
             
             $count{$date}{black}++ if ($color eq $color{black});

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -243,7 +243,11 @@ font-size: 10px;
     background-color: #990;
     color:            white;
 }
-.smfok, .smftest, .smfmissing, .smfbuild, .smfprereq {
+.smfwarn    , .smfwarn a      {
+    background-color: #ff8000;
+    color:            white;
+}
+.smfok, .smftest, .smfmissing, .smfbuild, .smfprereq, .smfwarn {
     text-align:         center;
     width:              30px;
     font-weight:        bold;

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -16,6 +16,7 @@
 </head>
 <body>
 <% content %>
+<a href="https://github.com/perl6-community-modules/SmokeResults"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div id="footer">
 Powered by <a href="http://perldancer.org/">Dancer</a> <% dancer_version %>
 </div>


### PR DESCRIPTION
This PR adds information on where the source for smoke.perl6.org can be found via a banner, and a little information on how the reports are generated in the README.  It also adds a new state for a distribution to be in - passing, but generating warnings.  This should make finding deprecation warnings earlier easier!

Depends on results being generated with https://github.com/tadzik/emmentaler/pull/3
